### PR TITLE
Added support for Formik and Yup in Hint FE

### DIFF
--- a/frontend/src/components/HintPageComponents/HintLeftAppearance/HintLeftAppearance.jsx
+++ b/frontend/src/components/HintPageComponents/HintLeftAppearance/HintLeftAppearance.jsx
@@ -1,13 +1,18 @@
 import React, { useMemo } from "react";
 import ColorTextField from "../../ColorTextField/ColorTextField";
 import "./HintLeftAppearance.css";
+  import { Formik, useFormikContext, Form } from "formik";
+  import * as Yup from "yup";
+
+const validationSchema = Yup.object().shape({
+  
+});
 
 const HintLeftAppearance = ({ data = [] }) => {
   const content = useMemo(() => {
     if (data.length === 0) {
       return <div className="hint-appearance-container">No data available</div>;
     }
-
     return (
       <div className="hint-appearance-container">
         {data.map(({ stateName, state, setState }) => (

--- a/frontend/src/components/HintPageComponents/HintLeftContent/HintLeftContent.jsx
+++ b/frontend/src/components/HintPageComponents/HintLeftContent/HintLeftContent.jsx
@@ -2,6 +2,12 @@ import React from "react";
 import DropdownList from "../../DropdownList/DropdownList";
 import CustomTextField from "../../TextFieldComponents/CustomTextField/CustomTextField";
 import "./HintLeftContent.css";
+import { Formik, useFormikContext, Form } from "formik";
+import * as Yup from "yup";
+
+const validationSchema = Yup.object().shape({
+  
+});
 
 const HintLeftContent = ({ actionButtonText, setActionButtonText, actionButtonUrl, setActionButtonUrl, action, setAction, targetElement, setTargetElement, tooltipPlacement, setTooltipPlacement }) => {
   const handleActionButtonText = (event) => {


### PR DESCRIPTION
## Describe your changes

This PR would add support for Formik and Yup to the following pages/components involved with Hint FE

`HintLeftContent.jsx`
![Screenshot 2025-01-10 at 7 22 55 PM](https://github.com/user-attachments/assets/24599787-dcc7-4596-950b-a9e504517c5f)

`HintLeftAppearance.jsx`
![Screenshot 2025-01-10 at 7 23 02 PM](https://github.com/user-attachments/assets/402d09f9-a331-473c-a6eb-7761a4409963)



## Issue number

This PR fixes #457 

## Please ensure all items are checked off before requesting a review:

- [ ] I deployed the code locally.
- [ ] I have performed a self-review of my code.
- [ ] I have included the issue # in the PR.
- [ ] I have labelled the PR correctly.
- [ ] The issue I am working on is assigned to me.
- [ ] I didn't use any hardcoded values (otherwise it will not scale, and will make it difficult to maintain consistency across the application).
- [ ] I made sure font sizes, color choices etc are all referenced from the theme.
- [ ] My PR is granular and targeted to one specific feature.
- [ ] I took a screenshot or a video and attached to this PR if there is a UI change.
