### PR TITLE
500 code script overflows in smaller screens

### DIFF
--- a/frontend/dist/index.html
+++ b/frontend/dist/index.html
@@ -6,8 +6,8 @@
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <title>Guidefox</title>
         <link rel="icon" type="image/svg+xml" href="/svg/favicon.svg" />
-      <script type="module" crossorigin src="/assets/index-DWYVBzNB.js"></script>
-      <link rel="stylesheet" crossorigin href="/assets/index-BSHa9UVa.css">
+      <script type="module" crossorigin src="/assets/index-DBm1Hrdr.js"></script>
+      <link rel="stylesheet" crossorigin href="/assets/index-x2uT4T0p.css">
     </head>
 
     <body>

--- a/frontend/src/scenes/settings/CodeTab/CodeTab.jsx
+++ b/frontend/src/scenes/settings/CodeTab/CodeTab.jsx
@@ -150,7 +150,7 @@ const CodeTab = () => {
                 />
             </div>
 
-            <pre><code>{codeToCopy}</code></pre>
+            <pre><code style={{ whiteSpace: "break-spaces"}}>{codeToCopy}</code></pre>
         </section>
     )
 }


### PR DESCRIPTION
## Describe your changes

Add white space to code tag so the text will split to fit the container.

![image](https://github.com/user-attachments/assets/70208281-ef81-47e8-8602-a99a97ba774e)

## Issue number

#500 

## Please ensure all items are checked off before requesting a review:

- [x] I deployed the code locally.
- [x] I have performed a self-review of my code.
- [x] I have included the issue # in the PR.
- [x] I have labelled the PR correctly.
- [x] The issue I am working on is assigned to me.
- [x] I didn't use any hardcoded values (otherwise it will not scale, and will make it difficult to maintain consistency across the application).
- [x] I made sure font sizes, color choices etc are all referenced from the theme.
- [x] My PR is granular and targeted to one specific feature.
- [x] I took a screenshot or a video and attached to this PR if there is a UI change.
