### PR TITLE
592 visualize selected target element for hints

### DIFF
--- a/extention/app.js
+++ b/extention/app.js
@@ -162,7 +162,11 @@ const createSendButton = () => {
       const url = `http://localhost:4173/tour?${queryParams.toString()}`;
       window.open(url, "_blank");
     } else if (selectedMode === "hint" && currentSelectedElement) {
-      console.log(currentSelectedElement);
+      queryParams.set("hintTarget", JSON.stringify(currentSelectedElement));
+      queryParams.set("autoOpen", "true");
+
+      const url = `http://localhost:4173/hint?${queryParams.toString()}`;
+      window.open(url, "_blank");
     }
   });
 

--- a/extention/app.js
+++ b/extention/app.js
@@ -4,12 +4,14 @@ const MENU_ID = "bw-ext-floating-menu";
 const INPUT_ID = "bw-ext-input";
 const BUTTON_ID = "bw-ext-button";
 const TOUR_STEPS_CONTAINER_ID = "bw-ext-tour-steps";
+const HINT_TARGET_CONTAINER_ID = "bw-ext-hint-target";
 const TOUR_STEP_CLASS = "bw-ext-tour-step";
 const AVAILABLE_MODES = ["hint", "tour"];
 let domSelected = false;
 let lastHighlightTarget;
 let selectedMode = "hint";
 let selectedElements = [];
+let currentSelectedElement = null;
 
 function terminate() {
   // The `click` listener is automatically removed after it has been called once
@@ -35,7 +37,7 @@ const createMenuDiv = () => {
   menuDiv.style.backgroundColor = "#f8f9fa";
   menuDiv.style.padding = "10px";
   menuDiv.style.cursor = "pointer";
-  menuDiv.style.minWidth = "160px";
+  menuDiv.style.minWidth = "250px";
   menuDiv.style.alignItems = "center";
   return menuDiv;
 };
@@ -48,18 +50,39 @@ const createMenuDivChildren = () => {
   buttonContainer.style.overflow = "hidden";
   buttonContainer.style.backgroundColor = "#ccc";
 
-  const cardContainer = document.createElement("div");
-  cardContainer.id = TOUR_STEPS_CONTAINER_ID;
-  cardContainer.style.display = "flex";
-  cardContainer.style.flexDirection = "column";
-  cardContainer.style.gap = "10px";
-  cardContainer.style.width = "100%";
-  cardContainer.style.maxHeight = "300px";
-  cardContainer.style.overflowY = "auto";
-  return { buttonContainer, cardContainer };
+  const tourContainer = document.createElement("div");
+  tourContainer.id = TOUR_STEPS_CONTAINER_ID;
+  tourContainer.style.display = "flex";
+  tourContainer.style.flexDirection = "column";
+  tourContainer.style.gap = "10px";
+  tourContainer.style.width = "100%";
+  tourContainer.style.maxHeight = "300px";
+  tourContainer.style.overflowY = "auto";
+
+  const hintContainer = document.createElement("div");
+  hintContainer.id = HINT_TARGET_CONTAINER_ID;
+  hintContainer.style.display = "flex";
+  hintContainer.style.flexDirection = "column";
+  hintContainer.style.gap = "10px";
+  hintContainer.style.width = "250px";
+  hintContainer.style.maxHeight = "300px";
+  hintContainer.style.overflowY = "auto";
+  hintContainer.style.border = "1px solid #ccc";
+  hintContainer.style.borderRadius = "6px";
+  hintContainer.style.padding = "10px";
+  hintContainer.style.boxSizing = "border-box";
+  hintContainer.style.backgroundColor = "#fff";
+  hintContainer.innerHTML = "No Target Selected";
+
+  return { buttonContainer, tourContainer, hintContainer };
 };
 
-const createMenuButton = (mode, buttonContainer, cardContainer) => {
+const createMenuButton = (
+  mode,
+  buttonContainer,
+  tourContainer,
+  hintContainer
+) => {
   const button = document.createElement("button");
   button.textContent = mode;
   button.style.padding = "8px 16px";
@@ -78,6 +101,8 @@ const createMenuButton = (mode, buttonContainer, cardContainer) => {
 
   button.addEventListener("click", () => {
     selectedMode = mode;
+
+    // Toggle button styles
     buttonContainer.childNodes.forEach((button) => {
       if (button.textContent !== selectedMode) {
         button.style.backgroundColor = "#ccc";
@@ -87,12 +112,19 @@ const createMenuButton = (mode, buttonContainer, cardContainer) => {
         button.style.color = "#fff";
       }
     });
+
+    // Toggle container visibility
     if (mode === "tour") {
+      tourContainer.style.display = "flex";
+      hintContainer.style.display = "none";
       generateList();
-    } else {
-      cardContainer.innerHTML = "";
+    } else if (mode === "hint") {
+      hintContainer.style.display = "flex";
+      tourContainer.style.display = "none";
+      setTargetHintValue();
     }
   });
+
   buttonContainer.appendChild(button);
 };
 
@@ -129,6 +161,8 @@ const createSendButton = () => {
 
       const url = `http://localhost:4173/tour?${queryParams.toString()}`;
       window.open(url, "_blank");
+    } else if (selectedMode === "hint" && currentSelectedElement) {
+      console.log(currentSelectedElement);
     }
   });
 
@@ -143,15 +177,17 @@ function createFloatingMenu() {
   const div = createMenuDiv();
   document.body.appendChild(div);
 
-  const { buttonContainer, cardContainer } = createMenuDivChildren();
+  const { buttonContainer, tourContainer, hintContainer } =
+    createMenuDivChildren();
 
   div.appendChild(buttonContainer);
-  div.appendChild(cardContainer);
+  div.appendChild(tourContainer);
+  div.appendChild(hintContainer);
 
   addDragEvent();
 
   AVAILABLE_MODES.forEach((mode) => {
-    createMenuButton(mode, buttonContainer, cardContainer);
+    createMenuButton(mode, buttonContainer, tourContainer, hintContainer);
   });
 
   // add event listener to drag the menu around
@@ -404,6 +440,7 @@ function generateList() {
     card.innerHTML = cardTemplate.replace("{{step}}", element);
     card.style.display = "flex";
     card.style.alignItems = "center";
+    card.style.justifyContent = "space-between";
     card.style.gap = "10px";
     card.style.color = "#344054";
     card.style.border = "1px solid #D0D5DD";
@@ -454,6 +491,12 @@ function generateList() {
   });
 }
 
+function setTargetHintValue() {
+  const cardContainer = document.getElementById(HINT_TARGET_CONTAINER_ID);
+
+  cardContainer.innerHTML = currentSelectedElement || "No Target Selected";
+}
+
 async function grabSelector(event) {
   event.preventDefault();
   const { target } = event;
@@ -470,6 +513,19 @@ async function grabSelector(event) {
     generateList();
     return;
   }
+
+  if (selectedMode === "hint") {
+    const selector = generateSelector(target);
+    currentSelectedElement = selector;
+
+    const hintContainer = document.getElementById(HINT_TARGET_CONTAINER_ID);
+    if (hintContainer) {
+      hintContainer.innerHTML = currentSelectedElement;
+    }
+
+    return;
+  }
+
   if (!(target instanceof HTMLElement)) {
     terminate();
     return;

--- a/frontend/src/scenes/hints/CreateHintPage.jsx
+++ b/frontend/src/scenes/hints/CreateHintPage.jsx
@@ -23,7 +23,9 @@ const HintPage = ({
   const [activeButton, setActiveButton] = useState(0);
 
   const params = new URLSearchParams(window.location.search);
-  const hintTarget = JSON.parse(params.get('hintTarget'));
+
+  const hintTargetParam = params.get('hintTarget');
+  const hintTarget = hintTargetParam ? JSON.parse(hintTargetParam) : null;
 
   const handleButtonClick = (index) => {
     setActiveButton(index);
@@ -69,10 +71,6 @@ const HintPage = ({
     tooltipPlacement,
     isHintIconVisible,
   } = leftContent;
-
-  useEffect(() => {
-    if (autoOpen) openDialog();
-  }, [autoOpen, openDialog]);
 
   const capitalizeFirstLetter = (string) => {
     return string.charAt(0).toUpperCase() + string.slice(1).toLowerCase();
@@ -125,9 +123,14 @@ const HintPage = ({
   }, [hintTarget, openDialog]);
 
   useEffect(() => {
-    if (autoOpen && hintTarget) preFillHintTarget();
-    else if (autoOpen) openDialog();
-  }, [autoOpen, openDialog]);
+    if (!autoOpen) return;
+
+    if (hintTarget) {
+      preFillHintTarget();
+    } else {
+      openDialog();
+    }
+  }, [autoOpen, hintTarget, preFillHintTarget, openDialog]);
 
   const onSave = async () => {
     const hintData = {

--- a/frontend/src/scenes/hints/HintDefaultPage.jsx
+++ b/frontend/src/scenes/hints/HintDefaultPage.jsx
@@ -18,6 +18,9 @@ const HintDefaultPage = () => {
   const { state } = useLocation();
   const { isOpen } = useDialog();
 
+  const params = new URLSearchParams(window.location.search);
+  const autoOpen = params.get('autoOpen') === 'true';
+
   const getHintDetails = (hint) => ({
     title: `Hint ${hint.id}`,
     text: hint.header,
@@ -37,9 +40,9 @@ const HintDefaultPage = () => {
         getItemById={getHintById}
         duplicateItem={addHint}
       />
-      {(isOpen || state?.autoOpen) && (
+      {(isOpen || state?.autoOpen || autoOpen) && (
         <CreateHintPage
-          autoOpen={state?.autoOpen}
+          autoOpen={state?.autoOpen || autoOpen}
           isEdit={isEdit}
           itemId={itemId}
           setItemsUpdated={setItemsUpdated}

--- a/frontend/src/templates/GuideTemplate/GuideTemplate.jsx
+++ b/frontend/src/templates/GuideTemplate/GuideTemplate.jsx
@@ -32,7 +32,7 @@ const GuideTemplate = ({
   const onCloseHandler = () => {
     if (location.state?.autoOpen) navigate('/', { state: {} });
 
-    //To remove the query string when redirecting the user to the createTour dashboard with prefilled values.
+    //To remove the query string when redirecting the user to the create guide dashboard with prefilled values.
     window.history.replaceState({}, '', window.location.pathname);
 
     closeDialog();

--- a/frontend/src/utils/hintHelper.js
+++ b/frontend/src/utils/hintHelper.js
@@ -20,13 +20,7 @@ const newHintSchema = Yup.object().shape({
     ['no action', 'open url', 'open url in a new tab'],
     'Invalid value for action'
   ),
-  targetElement: Yup.string().test(
-    'targetElement',
-    'Invalid value for targetElement',
-    (value) => {
-      return value.startsWith('#') || value.startsWith('.');
-    }
-  ),
+  targetElement: Yup.string().required('Target element cannot be empty'),
   tooltipPlacement: Yup.string().oneOf(
     ['top', 'bottom', 'right', 'left'],
     'Invalid value for tooltipPlacement'


### PR DESCRIPTION
## Describe your changes

- Redirects users to the createHint page on the dashboard with prefilled targetElement.
- Implemented query string clearing when data is saved or the tour hint is closed, ensuring proper behavior even when closed via the Cancel button or the Close (X) icon.

## Issue number

#592 

## Please ensure all items are checked off before requesting a review:

- [x] I deployed the code locally.
- [x] I have performed a self-review of my code.
- [x] I have included the issue # in the PR.
- [x] I have labelled the PR correctly.
- [x] The issue I am working on is assigned to me.
- [x] I didn't use any hardcoded values except redirecting to http://localhost:4173 (otherwise it will not scale, and will make it difficult to maintain consistency across the application).
- [x] I made sure font sizes, color choices etc are all referenced from the theme.
- [x] My PR is granular and targeted to one specific feature.
- [x] I took a screenshot or a video and attached to this PR if there is a UI change.

## Preview

### When no target element selected
![image](https://github.com/user-attachments/assets/d10d7e0d-3397-449b-9e5a-d451cd604358)

### When target element is selected
![image](https://github.com/user-attachments/assets/fe74036a-8a66-4fd0-a496-cffa2aa74343)
